### PR TITLE
change a little typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Supports both a configurable stylesheet association (stored as `xsl.stylesheet`)
 ## Prerequisities
 
 * A [Java](https://www.java.com/de/download/) installation. *Restart your Device after installation*  
-(Ensure Java is set in PATH by typing `java --version` in your console.)
+(Ensure Java is set in PATH by typing `java -version` in your console.)
 * The [Saxon XSL Processor](http://saxon.sourceforge.net/#F10HE) in the form of a jar.
 
 ## Quick Start


### PR DESCRIPTION
Regarding the version check of java and if it's executable, please use

java -version 

instead of 

java --version

